### PR TITLE
Give backstage access to local cluster to create k0rdent resources

### DIFF
--- a/app-config.production.yaml
+++ b/app-config.production.yaml
@@ -28,6 +28,20 @@ backend:
       #   ca: # if you have a CA file and want to verify it you can uncomment this section
       #     $file: <file-path>/ca/server.crt
 
+
+# Gives backstage access to the local cluster using a ServiceAccount
+kubernetes:
+  serviceLocatorMethod:
+    type: 'multiTenant'
+  clusterLocatorMethods:
+    - type: 'config'
+      clusters:
+        - name: in-cluster
+          url: https://kubernetes.default.svc
+          authProvider: 'serviceAccount'
+          skipTLSVerify: false
+          serviceAccountToken: ''
+          caFile: '/var/run/secrets/kubernetes.io/serviceaccount/ca.crt'
 auth:
   providers:
     guest:

--- a/kubernetes/deployment.yaml
+++ b/kubernetes/deployment.yaml
@@ -16,6 +16,7 @@ spec:
         app: backstage-k0rdent
     spec:
       containers:
+        serviceAccountName: backstage
         - name: backstage-k0rdent
           image: ghcr.io/barelyanxer/backstage:test8
           imagePullPolicy: Always

--- a/kubernetes/rbac/clusterrole.yaml
+++ b/kubernetes/rbac/clusterrole.yaml
@@ -1,0 +1,19 @@
+piVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: backstage-access
+rules:
+  # Full read access to all core and extended APIs (except Secrets)
+  - apiGroups: ["", "apps", "batch", "extensions", "*"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+
+  # Explicitly deny "secrets" (NOTE: Kubernetes RBAC doesn't have deny rules, so just exclude it)
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: []
+
+  # Allow full CRUD for ClusterDeployment in all namespaces
+  - apiGroups: ["k0rdent.mirantis.com"]
+    resources: ["clusterdeployments"]
+    verbs: ["create", "get", "list", "watch", "update", "patch", "delete"]

--- a/kubernetes/rbac/crb.yaml
+++ b/kubernetes/rbac/crb.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: backstage-access-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: backstage-access
+subjects:
+  - kind: ServiceAccount
+    name: backstage
+    namespace: backstage-k0rdent

--- a/kubernetes/rbac/serviceaccount.yaml
+++ b/kubernetes/rbac/serviceaccount.yaml
@@ -1,0 +1,5 @@
+piVersion: v1
+kind: ServiceAccount
+metadata:
+  name: backstage
+  namespace: backstage-k0rdent


### PR DESCRIPTION
Hey Christian,

This should allow backstage to connect to the local kubernetes cluster it's running in automatically. This way we can do things like create ClusterDeployment Objects. reach out to me with any questions.

Thanks!